### PR TITLE
refactor: use of tsconfig path resolutions / nextjs 9.5.1

### DIFF
--- a/apps/web-app/next.config.js
+++ b/apps/web-app/next.config.js
@@ -1,8 +1,23 @@
-// Tell webpack to compile those packages
-// https://www.npmjs.com/package/next-transpile-modules
-const withTM = require('next-transpile-modules')([
-    '@optional-package-scope/bar',
-    '@optional-package-scope/foo'
-])
+const path = require('path')
+module.exports = {
+    webpack: function (config, { defaultLoaders }) {
+        const resolvedBaseUrl = path.resolve(config.context, '../../')
+        config.module.rules = [
+            ...config.module.rules,
+            {
+                test: /\.(tsx|ts|js|mjs|jsx)$/,
+                include: [resolvedBaseUrl],
+                use: defaultLoaders.babel,
+                exclude: (excludePath) => {
+                    return /node_modules/.test(excludePath)
+                },
+            },
+        ]
+        return config
+    },
 
-module.exports = withTM({})
+    onDemandEntries: {
+        // Make sure entries are not getting disposed.
+        maxInactiveAge: 1000 * 60 * 60,
+    },
+}

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "typecheck": "tsc -p ./ --noEmit"
   },
   "devDependencies": {
     "@types/react": "^16.9.45",

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -16,7 +16,6 @@
     "@optional-package-scope/bar": "*",
     "@optional-package-scope/foo": "*",
     "next": "^9.5.2",
-    "next-transpile-modules": "^4.1.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3"
   },

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -6,19 +6,21 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "typecheck": "tsc -p ./ --noEmit"
+    "typecheck": "tsc -p ./ --noEmit",
+    "deps:check": "npx npm-check-updates --dep prod,dev,optional",
+    "deps:update": "npx npm-check-updates --dep prod,dev,optional -u"
   },
   "devDependencies": {
-    "@types/react": "^16.9.45",
-    "@types/node": "^14.0.27",
+    "@types/react": "^16.9.46",
+    "@types/node": "^14.6.0",
     "typescript": "^3.9.7"
   },
   "dependencies": {
     "@optional-package-scope/bar": "*",
     "@optional-package-scope/foo": "*",
     "next": "^9.5.2",
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "license": "ISC"
 }

--- a/apps/web-app/tsconfig.json
+++ b/apps/web-app/tsconfig.json
@@ -1,21 +1,6 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve"
   },
   "exclude": [

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "yarn --cwd apps/web-app dev",
     "build": "yarn --cwd apps/web-app build",
-    "start": "yarn --cwd apps/web-app start"
+    "start": "yarn --cwd apps/web-app start",
+    "typecheck": "yarn workspaces run typecheck"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev": "yarn --cwd apps/web-app dev",
     "build": "yarn --cwd apps/web-app build",
     "start": "yarn --cwd apps/web-app start",
-    "typecheck": "yarn workspaces run typecheck"
+    "typecheck": "yarn workspaces run typecheck",
+    "deps:check": "yarn workspaces run deps:check",
+    "deps:update": "yarn workspaces run deps:update"
   }
 }

--- a/packages/bar/index.ts
+++ b/packages/bar/index.ts
@@ -1,1 +1,0 @@
-export * from './src/index';

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "build": "microbundle --jsx React.createElement",
     "dev": "microbundle watch",
-    "typecheck": "tsc -p ./ --noEmit"
+    "typecheck": "tsc -p ./ --noEmit",
+    "deps:check": "npx npm-check-updates --dep prod,dev,optional",
+    "deps:update": "npx npm-check-updates --dep prod,dev,optional -u"
   },
   "devDependencies": {
     "typescript": "^3.9.7",

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -8,7 +8,8 @@
   "module": "dist/bar.module.js",
   "scripts": {
     "build": "microbundle --jsx React.createElement",
-    "dev": "microbundle watch"
+    "dev": "microbundle watch",
+    "typecheck": "tsc -p ./ --noEmit"
   },
   "devDependencies": {
     "typescript": "^3.9.7",

--- a/packages/bar/tsconfig.json
+++ b/packages/bar/tsconfig.json
@@ -1,29 +1,19 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react"
+    "jsx": "react",
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "build",
+    "composite": false
   },
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "build"
   ],
   "include": [
-    "**/*.ts",
-    "**/*.tsx"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ]
 }

--- a/packages/foo/index.ts
+++ b/packages/foo/index.ts
@@ -1,1 +1,0 @@
-export * from './src/index'

--- a/packages/foo/package.json
+++ b/packages/foo/package.json
@@ -4,7 +4,9 @@
   "license": "ISC",
   "private": true,
   "scripts": {
-    "typecheck": "tsc -p ./ --noEmit"
+    "typecheck": "tsc -p ./ --noEmit",
+    "deps:check": "npx npm-check-updates --dep prod,dev,optional",
+    "deps:update": "npx npm-check-updates --dep prod,dev,optional -u"
   },
   "devDependencies": {
     "typescript": "^3.9.7"

--- a/packages/foo/package.json
+++ b/packages/foo/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "license": "ISC",
   "private": true,
+  "scripts": {
+    "typecheck": "tsc -p ./ --noEmit"
+  },
   "devDependencies": {
     "typescript": "^3.9.7"
   }

--- a/packages/foo/tsconfig.json
+++ b/packages/foo/tsconfig.json
@@ -1,28 +1,18 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve"
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "build",
+    "composite": false
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "dist",
+    "build"
   ],
   "include": [
-    "**/*.ts",
-    "**/*.tsx"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     ],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@optional-package-scope/bar/*": ["packages/bar/src/*"],
+      "@optional-package-scope/bar": ["packages/bar/src/index"],
+      "@optional-package-scope/foo/*": ["packages/foo/src/*"],
+      "@optional-package-scope/foo": ["packages/foo/src/index"]
+    }
+  },
+  "exclude": [
+    "node_modules"
+  ]
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,7 +1855,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -4187,14 +4187,6 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
-
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -4376,14 +4368,6 @@ next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
-
-next-transpile-modules@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-4.1.0.tgz#b2d4bd29f3d4179014f7615720f360fdeec67ff7"
-  integrity sha512-brb9S2Dq7l01fV0fdZw1pO2cWMu7fFTclIV2nccmX2Jzwtz1c9iScPMqGyWP6/wglOPOColoJlHzOrSG6cnEIQ==
-  dependencies:
-    micromatch "^4.0.2"
-    slash "^3.0.0"
 
 next@^9.5.2:
   version "9.5.2"
@@ -4793,7 +4777,7 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,10 +1303,15 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
-"@types/node@*", "@types/node@^14.0.27":
+"@types/node@*":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
+
+"@types/node@^14.6.0":
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.0.tgz#7d4411bf5157339337d7cff864d9ff45f177b499"
+  integrity sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1323,7 +1328,7 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@types/react@^16.9.45":
+"@types/react@^16.9.46":
   version "16.9.46"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
   integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
@@ -5374,7 +5379,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-react-dom@^16.8.3:
+react-dom@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -5394,7 +5399,7 @@ react-refresh@0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react@^16.8.3:
+react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
Remove next-transpile-module in favour of tsconfig path resolutions. landed in 9.5.1 thx to https://github.com/vercel/next.js/pull/13542 

Current advantages over next-transpile-modules

- [x] Fast refresh works when you modify a package
- [ ] ??? Testing performance

Future:

Look at https://github.com/vercel/next.js/pull/15569
